### PR TITLE
Add CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ const escaped = escape('<script>"alert"</script>');
 // -> '&lt;script&gt;&quot;alert&quot;&lt;/script&gt;'
 ```
 
+### CLI Usage
+
+You can also sanitize input directly from the command line:
+
+```bash
+echo '<script>alert("xss")</script>' | npx unsane
+```
+
+This reads HTML from `stdin` and prints the sanitized result to `stdout`.
+
 ## Bundle Size
 
 This library is designed to be lightweight while providing comprehensive HTML sanitization:

--- a/bin/unsane
+++ b/bin/unsane
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { sanitize } from '../dist/index.js';
+
+let data = '';
+process.stdin.setEncoding('utf8');
+
+if (process.stdin.isTTY) {
+  console.error('Usage: echo "<html>" | unsane');
+  process.exit(1);
+}
+
+process.stdin.on('data', chunk => {
+  data += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const clean = sanitize(data);
+    process.stdout.write(clean);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "tsx": "^4.19.3",
     "typescript": "^5.0.0",
     "vitest": "^3.0.7"
+  },
+  "bin": {
+    "unsane": "./bin/unsane"
   }
 }


### PR DESCRIPTION
## Summary
- add `bin/unsane` CLI
- expose CLI via `bin` field
- document CLI usage example

## Testing
- `npm test` *(fails: coverage does not meet 100% threshold)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3ef9958832e83cc855bd08b506d