### PR TITLE
Add npmignore to slim package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+# Exclude development sources and configs
+src/
+test/
+dist/**/*.test.*
+dist/test/
+measure-size.ts
+bin/
+.github/
+.eslintrc.cjs
+vite.config.ts
+package-lock.json
+CHANGELOG.md
+SECURITY.md
+tsconfig*.json
+coverage


### PR DESCRIPTION
## Summary
- add `.npmignore` to exclude dev files from tarball
- ensure packed contents only contain compiled artifacts

## Testing
- `npm pack --dry-run --ignore-scripts`

------
https://chatgpt.com/codex/tasks/task_e_6840f3f5af84832e94db3792ef2e113f